### PR TITLE
Update target framework and version for Mail projects

### DIFF
--- a/Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
+++ b/Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>1.0.3</Version>
+	  <Version>9.0.0</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Aspire.Client.Mail</Product>

--- a/Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
+++ b/Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>1.0.3</Version>
+	  <Version>9.0.0</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Aspire.Hosting.MailDev</Product>


### PR DESCRIPTION
Updated target framework to net9.0 for both Berrevoets.Aspire.Client.Mail.csproj and Berrevoets.Aspire.Hosting.MailDev.csproj. Updated version number from 1.0.3 to 9.0.0 for both projects.