### PR TITLE
Add project documentation and markdownlint config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": {
+    "line_length": 120
+  },
+  "MD060": false
+}

--- a/Berrevoets.Aspire.Client.Mail/README.md
+++ b/Berrevoets.Aspire.Client.Mail/README.md
@@ -34,8 +34,9 @@ async (MailKitClientFactory factory, string email) =>
 ```
 
 ## Additional documentation
-https://learn.microsoft.com/dotnet/aspire
+
+<https://learn.microsoft.com/dotnet/aspire>
 
 ## Feedback & contributing
 
-https://github.com/bberrevoets/Berrevoets.Aspire.MailDev
+<https://github.com/bberrevoets/Berrevoets.Aspire.MailDev>

--- a/Berrevoets.Aspire.Hosting.MailDev/README.md
+++ b/Berrevoets.Aspire.Hosting.MailDev/README.md
@@ -24,8 +24,9 @@ var myService = builder.AddProject<Projects.MyService>()
 ```
 
 ## Additional documentation
-https://learn.microsoft.com/dotnet/aspire
+
+<https://learn.microsoft.com/dotnet/aspire>
 
 ## Feedback & contributing
 
-https://github.com/bberrevoets/Berrevoets.Aspire.MailDev
+<https://github.com/bberrevoets/Berrevoets.Aspire.MailDev>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [9.0.0] - 2024-10-11
+
+### Added
+
+- Update target framework to .NET 9.0 and bump package versions to 9.0.0
+- Add new Mail client project (`Berrevoets.Aspire.Client.Mail`)
+- Update CI pipeline for .NET 9.0 with separate host and client build steps
+
+### Changed
+
+- Remove project reference from Client.Mail (standalone package)
+
+## [8.2.1] - 2024-10-10
+
+### Features
+
+- Initial release
+- MailDev hosting integration for .NET Aspire (`Berrevoets.Aspire.Hosting.MailDev`)
+- `MailDevResource` with SMTP and HTTP endpoint support
+- `AddMailDev()` extension method for `IDistributedApplicationBuilder`
+- CI/CD workflows for preview and stable NuGet package publishing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+.NET Aspire integration for [MailDev](https://github.com/maildev/maildev), a
+fake SMTP server with a web UI for email testing. Ships as two NuGet packages:
+
+- **Berrevoets.Aspire.Hosting.MailDev** - Aspire hosting integration
+  (adds `builder.AddMailDev("maildev")` to the AppHost)
+- **Berrevoets.Aspire.Client.Mail** - Client library for consuming
+  the mail resource (currently a stub with no source files yet)
+
+## Build Commands
+
+```bash
+dotnet restore                    # Restore all packages
+dotnet build                      # Build entire solution
+dotnet build --configuration Release  # Release build
+dotnet test --no-restore --verbosity normal  # Run tests
+```
+
+Build a specific project:
+
+```bash
+dotnet build Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
+dotnet build Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
+```
+
+Run the test AppHost (requires Docker for MailDev container):
+
+```bash
+dotnet run --project MailDev.AppHost
+```
+
+## Architecture
+
+### NuGet Library Projects (packaged and published)
+
+- **Berrevoets.Aspire.Hosting.MailDev** - Contains two key types:
+  - `MailDevResource` (namespace `Aspire.Hosting.ApplicationModel`) - Custom
+    container resource implementing `IResourceWithConnectionString`. Exposes
+    SMTP (port 1025) and HTTP (port 1080) endpoints. Connection string format:
+    `smtp://{host}:{port}`
+  - `MailDevResourceBuilderExtensions` (namespace `Aspire.Hosting`) -
+    Extension method `AddMailDev()` on `IDistributedApplicationBuilder` that
+    configures the `maildev/maildev:2.1.0` Docker container
+- **Berrevoets.Aspire.Client.Mail** - Client-side library (no source files
+  yet). Intended for `builder.AddMailKitClient("maildev")` using MailKit
+
+### Test/Sample Projects (not published)
+
+- **MailDev.AppHost** - Aspire AppHost for local development/testing
+- **Berrevoets.Aspire.TestApp** - Minimal web app used by the AppHost
+- **MailDev.ServiceDefaults** - Standard Aspire service defaults
+  (OpenTelemetry, health checks, service discovery)
+
+## Conventions
+
+- Hosting resource types use namespace `Aspire.Hosting.ApplicationModel`
+- Hosting extension methods use namespace `Aspire.Hosting`
+- Both library projects target `net9.0` and generate NuGet packages on build
+- Package versions are set in each `.csproj` `<Version>` element
+- Container image tags are defined in `MailDevContainerImageTags` class
+
+## CI/CD
+
+Two GitHub Actions workflows:
+
+- **CI-development.yml** - Triggers on push/PR to `Development` branch.
+  Publishes `-preview` suffixed NuGet packages
+- **CI.yml** - Triggers on push/PR to `main` branch. Publishes final
+  (stable) NuGet packages
+
+Both workflows: restore, build Release, run tests, pack with symbols
+(`.snupkg`), and publish to NuGet.org.
+
+## Branch Strategy
+
+- `Development` - Default branch for active development (preview releases)
+- `main` - Production branch (stable releases)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# Maildev
+# Berrevoets.Aspire.MailDev
+
+.NET Aspire integration for [MailDev](https://github.com/maildev/maildev),
+a fake SMTP server with a web UI for email testing during development.
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [Berrevoets.Aspire.Hosting.MailDev](Berrevoets.Aspire.Hosting.MailDev/README.md) | Aspire hosting integration for MailDev |
+| [Berrevoets.Aspire.Client.Mail](Berrevoets.Aspire.Client.Mail/README.md) | Client library for consuming the mail resource |
+
+## Quick Start
+
+### AppHost setup
+
+In your AppHost project, add the hosting package:
+
+```dotnetcli
+dotnet add package Berrevoets.Aspire.Hosting.MailDev
+```
+
+Then register the MailDev resource:
+
+```csharp
+var maildev = builder.AddMailDev("maildev");
+
+var myService = builder.AddProject<Projects.MyService>()
+                       .WithReference(maildev);
+```
+
+### Client setup
+
+In your service project, add the client package:
+
+```dotnetcli
+dotnet add package Berrevoets.Aspire.Client.Mail
+```
+
+Then use the mail client:
+
+```csharp
+builder.AddMailKitClient("maildev");
+```
+
+## Building
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+## License
+
+This project is licensed under the GNU GPLv3 License. See the
+[LICENSE](LICENSE) file for details.
+
+## Feedback & Contributing
+
+<https://github.com/bberrevoets/Berrevoets.Aspire.MailDev>


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` for Claude Code guidance with build commands, architecture overview, and conventions
- Add `CHANGELOG.md` generated from git history
- Expand root `README.md` with package table, quick start guide, and build instructions
- Fix markdown lint issues in package README files (bare URLs, missing blank lines, trailing newline)
- Add `.markdownlint.json` with 120-char line length limit

## Test plan

- [ ] Verify markdown files render correctly on GitHub
- [ ] Verify markdownlint passes: `npx markdownlint-cli CLAUDE.md README.md CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)