### PR TITLE
Migrate to .NET 10 and Aspire 13.1.2

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -77,7 +77,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -68,7 +68,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,8 @@
   "MD013": {
     "line_length": 120
   },
+  "MD024": {
+    "siblings_only": true
+  },
   "MD060": false
 }

--- a/Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
+++ b/Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>9.0.0</Version>
+	  <Version>10.0.0</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Aspire.Client.Mail</Product>

--- a/Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
+++ b/Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>9.0.0</Version>
+	  <Version>10.0.0</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Aspire.Hosting.MailDev</Product>
@@ -39,7 +39,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting" Version="9.0.0" />
+		<PackageReference Include="Aspire.Hosting" Version="13.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Berrevoets.Aspire.Hosting.MailDev/MailDevResourceBuilderExtensions.cs
+++ b/Berrevoets.Aspire.Hosting.MailDev/MailDevResourceBuilderExtensions.cs
@@ -8,7 +8,7 @@ public static class MailDevResourceBuilderExtensions
 {
     /// <summary>
     ///     Adds the <see cref="MailDevResource" /> to the given
-    ///     <paramref name="builder" /> instance. Uses the "2.1.0" tag.
+    ///     <paramref name="builder" /> instance. Uses the "2.2.1" tag.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder" />.</param>
     /// <param name="name">The name of the resource.</param>
@@ -45,5 +45,5 @@ internal static class MailDevContainerImageTags
 
     internal const string Image = "maildev/maildev";
 
-    internal const string Tag = "2.1.0";
+    internal const string Tag = "2.2.1";
 }

--- a/Berrevoets.Aspire.TestApp/Berrevoets.Aspire.TestApp.csproj
+++ b/Berrevoets.Aspire.TestApp/Berrevoets.Aspire.TestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [10.0.0] - 2026-03-07
+
+### Changed
+
+- Migrate all projects from .NET 9 to .NET 10
+- Upgrade Aspire hosting from 9.0.0 to 13.1.2
+- Upgrade MailDev container image from 2.1.0 to 2.2.1
+- Upgrade Microsoft.Extensions.Http.Resilience to 10.3.0
+- Upgrade Microsoft.Extensions.ServiceDiscovery to 10.3.0
+- Upgrade all OpenTelemetry packages from 1.9.0 to 1.15.0
+- Restructure AppHost to use inline Aspire SDK reference
+- Add tracing filter to exclude health check endpoints
+- Update CI/CD workflows to use .NET 10 SDK
+- Add global.json pinning .NET 10 SDK
+
 ## [9.0.0] - 2024-10-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ dotnet run --project MailDev.AppHost
     `smtp://{host}:{port}`
   - `MailDevResourceBuilderExtensions` (namespace `Aspire.Hosting`) -
     Extension method `AddMailDev()` on `IDistributedApplicationBuilder` that
-    configures the `maildev/maildev:2.1.0` Docker container
+    configures the `maildev/maildev:2.2.1` Docker container
 - **Berrevoets.Aspire.Client.Mail** - Client-side library (no source files
   yet). Intended for `builder.AddMailKitClient("maildev")` using MailKit
 
@@ -61,7 +61,7 @@ dotnet run --project MailDev.AppHost
 
 - Hosting resource types use namespace `Aspire.Hosting.ApplicationModel`
 - Hosting extension methods use namespace `Aspire.Hosting`
-- Both library projects target `net9.0` and generate NuGet packages on build
+- Both library projects target `net10.0` and generate NuGet packages on build
 - Package versions are set in each `.csproj` `<Version>` element
 - Container image tags are defined in `MailDevContainerImageTags` class
 

--- a/MailDev.AppHost/MailDev.AppHost.csproj
+++ b/MailDev.AppHost/MailDev.AppHost.csproj
@@ -1,19 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>6ac3571f-bc10-47e5-9c6e-e2e58b353548</UserSecretsId>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Berrevoets.Aspire.Hosting.MailDev\Berrevoets.Aspire.Hosting.MailDev.csproj" IsAspireProjectResource="false" />

--- a/MailDev.ServiceDefaults/Extensions.cs
+++ b/MailDev.ServiceDefaults/Extensions.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Extensions.Hosting;
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+
     public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
         builder.ConfigureOpenTelemetry();
@@ -59,7 +62,12 @@ public static class Extensions
             .WithTracing(tracing =>
             {
                 tracing.AddSource(builder.Environment.ApplicationName)
-                    .AddAspNetCoreInstrumentation()
+                    .AddAspNetCoreInstrumentation(traceOptions =>
+                    {
+                        traceOptions.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath) &&
+                            !context.Request.Path.StartsWithSegments(AlivenessEndpointPath);
+                    })
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();
@@ -105,10 +113,10 @@ public static class Extensions
         if (app.Environment.IsDevelopment())
         {
             // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks("/health");
+            app.MapHealthChecks(HealthEndpointPath);
 
             // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks("/alive", new HealthCheckOptions
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
             {
                 Predicate = r => r.Tags.Contains("live")
             });

--- a/MailDev.ServiceDefaults/MailDev.ServiceDefaults.csproj
+++ b/MailDev.ServiceDefaults/MailDev.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

- Migrate all projects from `net9.0` to `net10.0` with package version bump to 10.0.0
- Upgrade Aspire hosting from 9.0.0 to 13.1.2 (inline SDK in AppHost, removed `Aspire.Hosting.AppHost` package)
- Upgrade MailDev container image from 2.1.0 to 2.2.1
- Upgrade OpenTelemetry packages from 1.9.0 to 1.15.0, Microsoft.Extensions packages from 9.0.0 to 10.3.0
- Add tracing filter in ServiceDefaults to exclude health check endpoint paths
- Update CI/CD workflows to use .NET 10 SDK
- Add `global.json` pinning .NET 10 SDK

## Test plan

- [x] `dotnet restore` succeeds
- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [x] `dotnet test` passes
- [ ] CI pipeline passes on GitHub Actions
- [ ] `dotnet run --project MailDev.AppHost` starts successfully (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)