### PR TITLE
Release v10.0.0 - .NET 10 and Aspire 13.1.2

### DIFF
--- a/.github/workflows/CI-development.yml
+++ b/.github/workflows/CI-development.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -77,7 +77,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore
@@ -68,7 +68,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": {
+    "line_length": 120
+  },
+  "MD060": false
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,8 @@
   "MD013": {
     "line_length": 120
   },
+  "MD024": {
+    "siblings_only": true
+  },
   "MD060": false
 }

--- a/Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
+++ b/Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>9.0.0</Version>
+	  <Version>10.0.0</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Aspire.Client.Mail</Product>

--- a/Berrevoets.Aspire.Client.Mail/README.md
+++ b/Berrevoets.Aspire.Client.Mail/README.md
@@ -34,8 +34,9 @@ async (MailKitClientFactory factory, string email) =>
 ```
 
 ## Additional documentation
-https://learn.microsoft.com/dotnet/aspire
+
+<https://learn.microsoft.com/dotnet/aspire>
 
 ## Feedback & contributing
 
-https://github.com/bberrevoets/Berrevoets.Aspire.MailDev
+<https://github.com/bberrevoets/Berrevoets.Aspire.MailDev>

--- a/Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
+++ b/Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>9.0.0</Version>
+	  <Version>10.0.0</Version>
 	  <Authors>Bert Berrevoets</Authors>
 	  <Company>Berrevoets Systems</Company>
 	  <Product>Berrevoets.Aspire.Hosting.MailDev</Product>
@@ -39,7 +39,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting" Version="9.0.0" />
+		<PackageReference Include="Aspire.Hosting" Version="13.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Berrevoets.Aspire.Hosting.MailDev/MailDevResourceBuilderExtensions.cs
+++ b/Berrevoets.Aspire.Hosting.MailDev/MailDevResourceBuilderExtensions.cs
@@ -8,7 +8,7 @@ public static class MailDevResourceBuilderExtensions
 {
     /// <summary>
     ///     Adds the <see cref="MailDevResource" /> to the given
-    ///     <paramref name="builder" /> instance. Uses the "2.1.0" tag.
+    ///     <paramref name="builder" /> instance. Uses the "2.2.1" tag.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder" />.</param>
     /// <param name="name">The name of the resource.</param>
@@ -45,5 +45,5 @@ internal static class MailDevContainerImageTags
 
     internal const string Image = "maildev/maildev";
 
-    internal const string Tag = "2.1.0";
+    internal const string Tag = "2.2.1";
 }

--- a/Berrevoets.Aspire.Hosting.MailDev/README.md
+++ b/Berrevoets.Aspire.Hosting.MailDev/README.md
@@ -24,8 +24,9 @@ var myService = builder.AddProject<Projects.MyService>()
 ```
 
 ## Additional documentation
-https://learn.microsoft.com/dotnet/aspire
+
+<https://learn.microsoft.com/dotnet/aspire>
 
 ## Feedback & contributing
 
-https://github.com/bberrevoets/Berrevoets.Aspire.MailDev
+<https://github.com/bberrevoets/Berrevoets.Aspire.MailDev>

--- a/Berrevoets.Aspire.TestApp/Berrevoets.Aspire.TestApp.csproj
+++ b/Berrevoets.Aspire.TestApp/Berrevoets.Aspire.TestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [10.0.0] - 2026-03-07
+
+### Changed
+
+- Migrate all projects from .NET 9 to .NET 10
+- Upgrade Aspire hosting from 9.0.0 to 13.1.2
+- Upgrade MailDev container image from 2.1.0 to 2.2.1
+- Upgrade Microsoft.Extensions.Http.Resilience to 10.3.0
+- Upgrade Microsoft.Extensions.ServiceDiscovery to 10.3.0
+- Upgrade all OpenTelemetry packages from 1.9.0 to 1.15.0
+- Restructure AppHost to use inline Aspire SDK reference
+- Add tracing filter to exclude health check endpoints
+- Update CI/CD workflows to use .NET 10 SDK
+- Add global.json pinning .NET 10 SDK
+
 ## [9.0.0] - 2024-10-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [9.0.0] - 2024-10-11
+
+### Added
+
+- Update target framework to .NET 9.0 and bump package versions to 9.0.0
+- Add new Mail client project (`Berrevoets.Aspire.Client.Mail`)
+- Update CI pipeline for .NET 9.0 with separate host and client build steps
+
+### Changed
+
+- Remove project reference from Client.Mail (standalone package)
+
+## [8.2.1] - 2024-10-10
+
+### Features
+
+- Initial release
+- MailDev hosting integration for .NET Aspire (`Berrevoets.Aspire.Hosting.MailDev`)
+- `MailDevResource` with SMTP and HTTP endpoint support
+- `AddMailDev()` extension method for `IDistributedApplicationBuilder`
+- CI/CD workflows for preview and stable NuGet package publishing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+.NET Aspire integration for [MailDev](https://github.com/maildev/maildev), a
+fake SMTP server with a web UI for email testing. Ships as two NuGet packages:
+
+- **Berrevoets.Aspire.Hosting.MailDev** - Aspire hosting integration
+  (adds `builder.AddMailDev("maildev")` to the AppHost)
+- **Berrevoets.Aspire.Client.Mail** - Client library for consuming
+  the mail resource (currently a stub with no source files yet)
+
+## Build Commands
+
+```bash
+dotnet restore                    # Restore all packages
+dotnet build                      # Build entire solution
+dotnet build --configuration Release  # Release build
+dotnet test --no-restore --verbosity normal  # Run tests
+```
+
+Build a specific project:
+
+```bash
+dotnet build Berrevoets.Aspire.Hosting.MailDev/Berrevoets.Aspire.Hosting.MailDev.csproj
+dotnet build Berrevoets.Aspire.Client.Mail/Berrevoets.Aspire.Client.Mail.csproj
+```
+
+Run the test AppHost (requires Docker for MailDev container):
+
+```bash
+dotnet run --project MailDev.AppHost
+```
+
+## Architecture
+
+### NuGet Library Projects (packaged and published)
+
+- **Berrevoets.Aspire.Hosting.MailDev** - Contains two key types:
+  - `MailDevResource` (namespace `Aspire.Hosting.ApplicationModel`) - Custom
+    container resource implementing `IResourceWithConnectionString`. Exposes
+    SMTP (port 1025) and HTTP (port 1080) endpoints. Connection string format:
+    `smtp://{host}:{port}`
+  - `MailDevResourceBuilderExtensions` (namespace `Aspire.Hosting`) -
+    Extension method `AddMailDev()` on `IDistributedApplicationBuilder` that
+    configures the `maildev/maildev:2.1.0` Docker container
+- **Berrevoets.Aspire.Client.Mail** - Client-side library (no source files
+  yet). Intended for `builder.AddMailKitClient("maildev")` using MailKit
+
+### Test/Sample Projects (not published)
+
+- **MailDev.AppHost** - Aspire AppHost for local development/testing
+- **Berrevoets.Aspire.TestApp** - Minimal web app used by the AppHost
+- **MailDev.ServiceDefaults** - Standard Aspire service defaults
+  (OpenTelemetry, health checks, service discovery)
+
+## Conventions
+
+- Hosting resource types use namespace `Aspire.Hosting.ApplicationModel`
+- Hosting extension methods use namespace `Aspire.Hosting`
+- Both library projects target `net9.0` and generate NuGet packages on build
+- Package versions are set in each `.csproj` `<Version>` element
+- Container image tags are defined in `MailDevContainerImageTags` class
+
+## CI/CD
+
+Two GitHub Actions workflows:
+
+- **CI-development.yml** - Triggers on push/PR to `Development` branch.
+  Publishes `-preview` suffixed NuGet packages
+- **CI.yml** - Triggers on push/PR to `main` branch. Publishes final
+  (stable) NuGet packages
+
+Both workflows: restore, build Release, run tests, pack with symbols
+(`.snupkg`), and publish to NuGet.org.
+
+## Branch Strategy
+
+- `Development` - Default branch for active development (preview releases)
+- `main` - Production branch (stable releases)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ dotnet run --project MailDev.AppHost
     `smtp://{host}:{port}`
   - `MailDevResourceBuilderExtensions` (namespace `Aspire.Hosting`) -
     Extension method `AddMailDev()` on `IDistributedApplicationBuilder` that
-    configures the `maildev/maildev:2.1.0` Docker container
+    configures the `maildev/maildev:2.2.1` Docker container
 - **Berrevoets.Aspire.Client.Mail** - Client-side library (no source files
   yet). Intended for `builder.AddMailKitClient("maildev")` using MailKit
 
@@ -61,7 +61,7 @@ dotnet run --project MailDev.AppHost
 
 - Hosting resource types use namespace `Aspire.Hosting.ApplicationModel`
 - Hosting extension methods use namespace `Aspire.Hosting`
-- Both library projects target `net9.0` and generate NuGet packages on build
+- Both library projects target `net10.0` and generate NuGet packages on build
 - Package versions are set in each `.csproj` `<Version>` element
 - Container image tags are defined in `MailDevContainerImageTags` class
 

--- a/MailDev.AppHost/MailDev.AppHost.csproj
+++ b/MailDev.AppHost/MailDev.AppHost.csproj
@@ -1,19 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+<Project Sdk="Aspire.AppHost.Sdk/13.1.2">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>6ac3571f-bc10-47e5-9c6e-e2e58b353548</UserSecretsId>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Berrevoets.Aspire.Hosting.MailDev\Berrevoets.Aspire.Hosting.MailDev.csproj" IsAspireProjectResource="false" />

--- a/MailDev.ServiceDefaults/Extensions.cs
+++ b/MailDev.ServiceDefaults/Extensions.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Extensions.Hosting;
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
+    private const string HealthEndpointPath = "/health";
+    private const string AlivenessEndpointPath = "/alive";
+
     public static TBuilder AddServiceDefaults<TBuilder>(this TBuilder builder) where TBuilder : IHostApplicationBuilder
     {
         builder.ConfigureOpenTelemetry();
@@ -59,7 +62,12 @@ public static class Extensions
             .WithTracing(tracing =>
             {
                 tracing.AddSource(builder.Environment.ApplicationName)
-                    .AddAspNetCoreInstrumentation()
+                    .AddAspNetCoreInstrumentation(traceOptions =>
+                    {
+                        traceOptions.Filter = context =>
+                            !context.Request.Path.StartsWithSegments(HealthEndpointPath) &&
+                            !context.Request.Path.StartsWithSegments(AlivenessEndpointPath);
+                    })
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();
@@ -105,10 +113,10 @@ public static class Extensions
         if (app.Environment.IsDevelopment())
         {
             // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks("/health");
+            app.MapHealthChecks(HealthEndpointPath);
 
             // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks("/alive", new HealthCheckOptions
+            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
             {
                 Predicate = r => r.Tags.Contains("live")
             });

--- a/MailDev.ServiceDefaults/MailDev.ServiceDefaults.csproj
+++ b/MailDev.ServiceDefaults/MailDev.ServiceDefaults.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
@@ -10,13 +10,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Berrevoets.Play.Economy.Common
+# Maildev

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# Maildev
+# Berrevoets.Aspire.MailDev
+
+.NET Aspire integration for [MailDev](https://github.com/maildev/maildev),
+a fake SMTP server with a web UI for email testing during development.
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [Berrevoets.Aspire.Hosting.MailDev](Berrevoets.Aspire.Hosting.MailDev/README.md) | Aspire hosting integration for MailDev |
+| [Berrevoets.Aspire.Client.Mail](Berrevoets.Aspire.Client.Mail/README.md) | Client library for consuming the mail resource |
+
+## Quick Start
+
+### AppHost setup
+
+In your AppHost project, add the hosting package:
+
+```dotnetcli
+dotnet add package Berrevoets.Aspire.Hosting.MailDev
+```
+
+Then register the MailDev resource:
+
+```csharp
+var maildev = builder.AddMailDev("maildev");
+
+var myService = builder.AddProject<Projects.MyService>()
+                       .WithReference(maildev);
+```
+
+### Client setup
+
+In your service project, add the client package:
+
+```dotnetcli
+dotnet add package Berrevoets.Aspire.Client.Mail
+```
+
+Then use the mail client:
+
+```csharp
+builder.AddMailKitClient("maildev");
+```
+
+## Building
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+## License
+
+This project is licensed under the GNU GPLv3 License. See the
+[LICENSE](LICENSE) file for details.
+
+## Feedback & Contributing
+
+<https://github.com/bberrevoets/Berrevoets.Aspire.MailDev>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary

- Migrate all projects from `net9.0` to `net10.0` with package version bump to 10.0.0
- Upgrade Aspire hosting from 9.0.0 to 13.1.2 (inline SDK in AppHost, removed `Aspire.Hosting.AppHost` package)
- Upgrade MailDev container image from 2.1.0 to 2.2.1
- Upgrade OpenTelemetry packages from 1.9.0 to 1.15.0, Microsoft.Extensions packages from 9.0.0 to 10.3.0
- Add tracing filter in ServiceDefaults to exclude health check endpoint paths
- Update CI/CD workflows to use .NET 10 SDK
- Add `global.json` pinning .NET 10 SDK
- Add project documentation (CLAUDE.md, CHANGELOG.md, markdownlint config)

## Test plan

- [x] `dotnet restore` succeeds
- [x] `dotnet build` succeeds with 0 warnings, 0 errors
- [x] `dotnet test` passes
- [ ] CI pipeline passes on GitHub Actions
- [ ] `dotnet run --project MailDev.AppHost` starts successfully (requires Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)